### PR TITLE
Dev reload fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
     "chrome": false,
     "window": false,
     "googletag": true,
-    "document": false
+    "document": false,
+    "__webpack_hash__": false
   },
   "extends": ["airbnb-base"]
 }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -59,4 +59,14 @@ chrome.runtime.onConnect.addListener((port) => {
     GptListeners(store, msg, windowTabId);
     GptEventListeners(store, msg, windowTabId);
   });
+
+  if (process.env.NODE_ENV === 'development') {
+    // reload extension if current hash changes
+    port.onMessage.addListener((msg) => {
+      if (msg.type === 'EXTENSION_RELOAD') {
+        chrome.tabs.reload(port.sender.tab.id);
+        chrome.runtime.reload();
+      }
+    });
+  }
 });

--- a/src/scripts/inject_script.js
+++ b/src/scripts/inject_script.js
@@ -4,8 +4,23 @@ import eventListeners from './Listeners/InjectScript';
 
 window.googletag = window.googletag || {};
 
+const { dispatchEvent, CustomEvent } = window;
+
 googletag.cmd = [() => {
   // patchRefresh(googletag);
   slot(googletag);
   eventListeners(googletag);
 }, ...googletag.cmd || []];
+
+/* Reload content and background scripts
+    - sends current hash to long running content/background script
+    - content script reloads chrome runtime if hashes don't match
+*/
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line
+  dispatchEvent(new CustomEvent('EXTENSION_RELOAD', {
+    detail: {
+      hash: __webpack_hash__,
+    },
+  }));
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,7 @@
-const { execSync } = require('child_process');
+
 const webpack = require('webpack');
 const path = require('path');
-const MinifyPlugin = require("babel-minify-webpack-plugin");
-const WebpackOnBuildPlugin = require('on-build-webpack');
+const MinifyPlugin = require('babel-minify-webpack-plugin');
 const merge = require('webpack-merge');
 
 const SCRIPTS_DIR = path.join(__dirname, 'src/scripts');
@@ -10,60 +9,17 @@ const EXTENSION_DIR = path.join(__dirname, 'extension/dist');
 
 const POPUP_ENTRY = path.join(__dirname, 'src/index.jsx');
 
-function getActiveTab() {
-  let activeTab = execSync('chrome-cli info');
-  return activeTab.toString().split('\n')[0].split(': ')[1];
-}
-
-function createOrReloadExtensions(activeTab) {
-  let chromeTabs = execSync('chrome-cli list tabs');
-
-  if (chromeTabs.includes('Extensions')) {
-    const extExp = /\]\ Extensions$/s;
-    let tab = chromeTabs.toString().split('\n').reduce((val, next) => {
-      if (extExp.test(next)) {
-        return next;
-      }
-      return val;
-    }, '');
-    if (tab) {
-      let closeBracketInd = tab.indexOf(']');
-      let windowInd = tab.indexOf(':');
-      let tabId = windowInd ? tab.substring(windowInd + 1, closeBracketInd) : tab.substring(1, closeBracketInd);
-      execSync(`chrome-cli reload -t ${tabId}; chrome-cli reload -t ${activeTab}`);
-    } else {
-      execSync(`chrome-cli open chrome://extensions; chrome-cli activate -t ${activeTab}; chrome-cli reload -t ${activeTab}`);
-    }
-  } else {
-    execSync(`chrome-cli open chrome://extensions; chrome-cli activate -t ${activeTab}; chrome-cli reload -t ${activeTab}`);
-  }
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 const production = {
   devtool: 'source-map',
   plugins: [
     new MinifyPlugin({}, { test: /\.(js|jsx)$/i }),
-  ]
-}
+  ],
+};
 
 const hot = {
   entry: [
     'webpack-dev-server/client?http://localhost:3001',
-    'webpack/hot/only-dev-server'
+    'webpack/hot/only-dev-server',
   ],
   output: {
     publicPath: '/dist',
@@ -76,17 +32,17 @@ const hot = {
         loader: 'babel-loader',
         options: {
           presets: [
-            ['@babel/preset-es2015', {"modules": false}],
+            ['@babel/preset-es2015', { modules: false }],
           ],
-          plugins: ["react-hot-loader/babel"]
-        }
-      }]
+          plugins: ['react-hot-loader/babel'],
+        },
+      }],
     }],
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
-  ]
+  ],
 };
 
 const scripts = {
@@ -105,24 +61,22 @@ const scripts = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: [{
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              ['@babel/preset-es2015'],
-              ['@babel/preset-stage-0']
-            ],
-          }
-        },
-        'eslint-loader',
-      ],
-    }],
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                ['@babel/preset-es2015'],
+                ['@babel/preset-stage-0'],
+              ],
+            },
+          },
+          'eslint-loader',
+        ],
+      },
+    ],
   },
-  plugins: [
-    new WebpackOnBuildPlugin(function(stats) {
-      // createOrReloadExtensions(getActiveTab());
-    }),
-  ],
+  plugins: [],
 };
 
 const popup = {
@@ -140,15 +94,15 @@ const popup = {
         loader: 'babel-loader',
         options: {
           plugins: [
-              '@babel/plugin-transform-runtime',
+            '@babel/plugin-transform-runtime',
           ],
           presets: [
             ['@babel/preset-es2015'],
             ['@babel/preset-stage-0'],
-            ['@babel/preset-react']
+            ['@babel/preset-react'],
           ],
-        }
-      }]
+        },
+      }],
     },
     {
       test: /\.css$/,
@@ -161,21 +115,21 @@ const popup = {
       use: 'file-loader',
     }],
   },
-  plugins: []
-}
+  plugins: [],
+};
 
 const configs = {
   production,
   hot,
   scripts,
   popup,
-}
+};
 
 
 module.exports = ((env = {}) => {
   const { BUILD_TYPE, NODE_ENV } = env;
   const base = configs[BUILD_TYPE];
-  
+
   return merge.smartStrategy({ entry: 'prepend', plugins: 'replace' })(base, configs[NODE_ENV] || {});
 });
 


### PR DESCRIPTION
Reloading chrome's extension tab seems to no longer reload an extension's content and background scripts.

Using a different hacky way to reload the extension by injecting the build hash into the bundle. Since the script injected into the DOM by the content script is a new instance on every tab refresh, the injected script has the most recent build hash. So we send the new build hash to the content script to compare with it's own, if they don't match up send a signal to the background script to reload the chrome runtime and restart the content and background script processes with the most current changes.